### PR TITLE
feat: add ui5 middleware code coverage

### DIFF
--- a/generators/app/templates/_.gitignore
+++ b/generators/app/templates/_.gitignore
@@ -14,3 +14,4 @@ node_modules/
 
 .DS_Store
 .env
+tmp/

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -18,6 +18,7 @@
 	},
 	"devDependencies": {
 		"@ui5/cli": "^3.6.1",
+		"@ui5/middleware-code-coverage": "^1.1.0",
 		"eslint": "^8.50.0",
 		"karma": "^6.4.2",
 		"karma-chrome-launcher": "^3.2.0",

--- a/generators/app/templates/test/_library_/qunit/testsuite.qunit.js
+++ b/generators/app/templates/test/_library_/qunit/testsuite.qunit.js
@@ -20,7 +20,11 @@ sap.ui.define(function () {
 				qunitBridge: true,
 				useFakeTimers: false
 			},
-			module: "./{name}.qunit"
+			module: "./{name}.qunit",
+			coverage: {
+				only: ["<%= libURI %>/"],
+				never: ["test-resources/"]
+			}
 		},
 		tests: {
 			// test file for the Example control

--- a/generators/app/templates/ui5.yaml
+++ b/generators/app/templates/ui5.yaml
@@ -12,3 +12,5 @@ server:
   customMiddleware:
     - name: ui5-middleware-livereload
       afterMiddleware: compression
+    - name: "@ui5/middleware-code-coverage"
+      afterMiddleware: compression


### PR DESCRIPTION
Allows client side code coverage generation for ES6+ code powered by https://github.com/SAP/ui5-tooling-extensions/tree/main/packages/middleware-code-coverage.

Projects generated for UI5 versions before 1.113.0 will stick to old "Blanket.js" based code coverage determination limited to ES5 language specification.

JIRA: CPOUI5FOUNDATION-721